### PR TITLE
Backward compatybility with previous version allowing pulling Advanced_Sidebar_Menu_List_Pages listings. 

### DIFF
--- a/src/Advanced_Sidebar_Menu_List_Pages.php
+++ b/src/Advanced_Sidebar_Menu_List_Pages.php
@@ -100,9 +100,9 @@ class Advanced_Sidebar_Menu_List_Pages{
 	 *
 	 * @param int                        $parent_id - $asm->top_id
 	 * @param Advanced_Sidebar_Menu_Menu $asm
-	 * @param WP_Post $current_page;
+	 * @param WP_Post|null $current_page;
 	 */
-	public function __construct( $parent_id, Advanced_Sidebar_Menu_Menu $asm, $current_page ){
+	public function __construct( $parent_id, Advanced_Sidebar_Menu_Menu $asm, $current_page = null ){
 		$this->menu = $asm;
 		$this->top_parent_id = $parent_id;
 		$this->current_page = $current_page;

--- a/src/Advanced_Sidebar_Menu_List_Pages.php
+++ b/src/Advanced_Sidebar_Menu_List_Pages.php
@@ -100,9 +100,9 @@ class Advanced_Sidebar_Menu_List_Pages{
 	 *
 	 * @param int                        $parent_id - $asm->top_id
 	 * @param Advanced_Sidebar_Menu_Menu $asm
-	 * @param WP_Post|null $current_page;
+	 * @param WP_Post $current_page;
 	 */
-	public function __construct( $parent_id, Advanced_Sidebar_Menu_Menu $asm, $current_page = null ){
+	public function __construct( $parent_id, Advanced_Sidebar_Menu_Menu $asm, $current_page ){
 		$this->menu = $asm;
 		$this->top_parent_id = $parent_id;
 		$this->current_page = $current_page;
@@ -144,11 +144,11 @@ class Advanced_Sidebar_Menu_List_Pages{
 	 *
 	 *
 	 * @param array         $classes
-	 * @param \WP_Post $post
+	 * @param $post
 	 *
 	 * @return array
 	 */
-	public function add_list_item_classes( $classes, WP_Post $post ) {
+	public function add_list_item_classes( $classes, post ) {
 		if( $post->ID === $this->top_parent_id ){
 			$children = $this->get_child_pages( $post->ID, true );
 		} else {


### PR DESCRIPTION
Previous version allowed me to create custom sidebar object which I've used in dynamic way. The previous declaration did not contain the "$current_page" parameter, so it would be a good idea to allow having null param there.

Consider following:

```
// retrieve advanced sidebar menu manually
$menuInstance = new Advanced_Sidebar_Menu_Menu();
$listInstance = new Advanced_Sidebar_Menu_List_Pages($postID, $menuInstance);

// retrieve page's children pages.
$listPages = $listInstance->list_pages();
```