### PR TITLE
Update WordPress stubs to "7.0.1 as 6.9.4" in pull-request-lint workflow

### DIFF
--- a/.github/workflows/pull-request-lint.yml
+++ b/.github/workflows/pull-request-lint.yml
@@ -78,7 +78,7 @@ jobs:
             phpstan-version: 3.4.2
             stubs: 6.2.6
           - php: 8.5
-            stubs: 7.0.0
+            stubs: "7.0.1 as 6.9.4"
     uses: lipemat/public-actions/.github/workflows/phpstan-plugin.yml@version/2
     with:
       php: ${{ matrix.combination.php }}

--- a/js/src/gutenberg/blocks/Display.tsx
+++ b/js/src/gutenberg/blocks/Display.tsx
@@ -9,6 +9,7 @@ import {Taxonomy} from '@wordpress/api/taxonomies';
 import ErrorBoundary from '../../components/ErrorBoundary';
 import {BlockEditProps} from '@wordpress/blocks';
 import {PropsWithChildren} from 'react';
+import {NEXT_40PX_DEFAULT_SIZE_CLASS} from '../next-40px-default-size';
 
 
 export type DisplayOptions = {
@@ -105,7 +106,7 @@ const Display = ( {
 					key={'levels'}
 					/* translators: %s {select HTML input}, {post type plural label} */
 					label={sprintf( __( 'Levels of child %s to display', 'advanced-sidebar-menu' ), type?.labels?.name.toLowerCase() ?? '' )}
-					className={'advanced-sidebar-menu-display-select'}
+					className={`advanced-sidebar-menu-display-select ${NEXT_40PX_DEFAULT_SIZE_CLASS}`}
 					value={attributes.levels.toString()}
 					onChange={value => {
 						setAttributes( {

--- a/js/src/gutenberg/blocks/ExcludeField.tsx
+++ b/js/src/gutenberg/blocks/ExcludeField.tsx
@@ -6,6 +6,7 @@ import {Attr as CategoryAttr} from './categories/block';
 import {BlockEditProps} from '@wordpress/blocks';
 import {Taxonomy} from '@wordpress/api/taxonomies';
 import DOMPurify from 'dompurify';
+import {NEXT_40PX_DEFAULT_SIZE_CLASS} from '../next-40px-default-size';
 
 type Props = {
 	attributes: PageAttr | CategoryAttr;
@@ -42,6 +43,8 @@ const ExcludeField = ( {type, attributes, setAttributes}: Props ) => {
 			}}
 			// @ts-expect-error -- Not technically supported until WP 6.7
 			__nextHasNoMarginBottom
+			__next40pxDefaultSize
+			className={NEXT_40PX_DEFAULT_SIZE_CLASS}
 		/>
 	);
 };

--- a/js/src/gutenberg/blocks/categories/Edit.tsx
+++ b/js/src/gutenberg/blocks/categories/Edit.tsx
@@ -16,6 +16,7 @@ import {isScreen} from '../../helpers';
 import ExcludeField from '../ExcludeField';
 
 import styles from '../pages/edit.pcss';
+import {NEXT_40PX_DEFAULT_SIZE_CLASS} from '../../next-40px-default-size';
 
 
 export type FillProps =
@@ -70,6 +71,8 @@ const Edit = ( {attributes, setAttributes, clientId, name}: Props ) => {
 					onChange={title => setAttributes( {title} )}
 					// @ts-expect-error -- Not technically supported until WP 6.7
 					__nextHasNoMarginBottom
+					__next40pxDefaultSize
+					className={NEXT_40PX_DEFAULT_SIZE_CLASS}
 				/>
 			</PanelBody>}
 			<ErrorBoundary attributes={attributes} block={name} section={'categories/Edit/general'}>
@@ -113,6 +116,10 @@ const Edit = ( {attributes, setAttributes, clientId, name}: Props ) => {
 							} ) )}
 							/* eslint-disable-next-line camelcase */
 							onChange={new_widget => setAttributes( {new_widget} )}
+							// @ts-expect-error -- Not technically supported until WP 6.7
+							__nextHasNoMarginBottom
+							__next40pxDefaultSize
+							className={NEXT_40PX_DEFAULT_SIZE_CLASS}
 						/>}
 				</Display>
 

--- a/js/src/gutenberg/blocks/pages/Edit.tsx
+++ b/js/src/gutenberg/blocks/pages/Edit.tsx
@@ -1,19 +1,21 @@
 import {BlockControls, InspectorControls} from '@wordpress/block-editor';
 import {PanelBody, SelectControl, Slot, TextControl} from '@wordpress/components';
 import {BlockEditProps} from '@wordpress/blocks';
+import DOMPurify from 'dompurify';
+import {useSelect} from '@wordpress/data';
+import {__} from '@wordpress/i18n';
+import {Type} from '@wordpress/api/types';
+
 import {Attr, block} from './block';
 import Preview from '../Preview';
 import Display from '../Display';
-import {useSelect} from '@wordpress/data';
 import InfoPanel from '../InfoPanel';
 import {CONFIG} from '../../../globals/config';
-import {__} from '@wordpress/i18n';
-import {Type} from '@wordpress/api/types';
 import ErrorBoundary from '../../../components/ErrorBoundary';
 import SideLoad from '../../SideLoad';
 import {isScreen} from '../../helpers';
 import ExcludeField from '../ExcludeField';
-import DOMPurify from 'dompurify';
+import {NEXT_40PX_DEFAULT_SIZE_CLASS} from '../../next-40px-default-size';
 
 import styles from './edit.pcss';
 
@@ -74,6 +76,8 @@ const Edit = ( {attributes, setAttributes, clientId, name}: Props ) => {
 					onChange={title => setAttributes( {title} )}
 					// @ts-expect-error -- Not technically supported until WP 6.7
 					__nextHasNoMarginBottom
+					__next40pxDefaultSize
+					className={NEXT_40PX_DEFAULT_SIZE_CLASS}
 				/>
 			</PanelBody>}
 			<ErrorBoundary attributes={attributes} block={name} section={'pages/Edit/general'}>
@@ -101,7 +105,12 @@ const Edit = ( {attributes, setAttributes, clientId, name}: Props ) => {
 							setAttributes( {
 								order_by: value,
 							} );
-						}} />
+						}}
+						// @ts-expect-error -- Not technically supported until WP 6.7
+						__nextHasNoMarginBottom
+						__next40pxDefaultSize
+						className={NEXT_40PX_DEFAULT_SIZE_CLASS}
+					/>
 
 					<ExcludeField
 						type={postType}

--- a/js/src/gutenberg/index.ts
+++ b/js/src/gutenberg/index.ts
@@ -4,6 +4,8 @@ import {getBlockSupports, TransformLegacy, transformLegacyWidget, translateBlock
 import ErrorBoundary from '../components/ErrorBoundary';
 import NavigationIcon from './blocks/NavigationIcon';
 
+import './next-40px-default-size.pcss';
+
 
 // @see content/plugins/advanced-sidebar-menu-pro/js/src/globals/config.ts
 export type PassedGlobals = Partial<{

--- a/js/src/gutenberg/next-40px-default-size.pcss
+++ b/js/src/gutenberg/next-40px-default-size.pcss
@@ -1,0 +1,27 @@
+/**
+ * `@wordpress/components` only applies the `is-next-40px-default-size` /
+ * 40px sizing when the `__next40pxDefaultSize` prop is both passed and
+ * recognized by the installed `@wordpress/components` version.
+ *
+ * Older WordPress versions ignore the prop, current versions honor it, and
+ * future versions will make it the permanent default and ignore the prop
+ * entirely. Applying the same sizing directly, here, keeps every control
+ * a consistent 40px across all of them.
+ *
+ * @see https://github.com/WordPress/gutenberg/blob/trunk/packages/components/src/text-control/index.tsx
+ * @see https://github.com/WordPress/gutenberg/blob/trunk/packages/components/src/select-control/styles/select-control-styles.ts
+ */
+:global(.advanced-sidebar-menu-next-40px-default-size) { /* stylelint-disable-line */
+
+	:global(.components-text-control__input) { /* stylelint-disable-line */
+		height: 2.5rem !important;
+		padding-left: .75rem !important;
+		padding-right: .75rem !important;
+	}
+
+	:global(.components-select-control__input) { /* stylelint-disable-line */
+		height: 2.5rem !important;
+		min-height: 2.5rem !important;
+		padding: 0 1.875rem 0 .75rem !important;
+	}
+}

--- a/js/src/gutenberg/next-40px-default-size.ts
+++ b/js/src/gutenberg/next-40px-default-size.ts
@@ -1,0 +1,9 @@
+/**
+ * Marker class applied to `TextControl`/`SelectControl` instances that
+ * should render at the `__next40pxDefaultSize` height/padding regardless
+ * of whether the running WordPress version's `@wordpress/components`
+ * recognizes that prop.
+ *
+ * @see ./next-40px-default-size.pcss
+ */
+export const NEXT_40PX_DEFAULT_SIZE_CLASS = 'advanced-sidebar-menu-next-40px-default-size';

--- a/src/Scripts.php
+++ b/src/Scripts.php
@@ -98,7 +98,7 @@ class Scripts {
 	 *
 	 * @return void
 	 */
-	public function register_gutenberg_scripts() {
+	public function register_gutenberg_scripts(): void {
 		wp_register_script( static::GUTENBERG_HANDLE, $this->get_dist_file( self::FILE_BLOCK_EDITOR, 'js' ), [
 			'jquery',
 			'lodash',
@@ -268,7 +268,7 @@ class Scripts {
 	 *
 	 * @return void
 	 */
-	public function init_widget_js() {
+	public function init_widget_js(): void {
 		if ( WP_DEBUG ) {
 			?>
 			<!-- <?php echo __FILE__; ?>-->
@@ -295,7 +295,7 @@ class Scripts {
 	 * @param string               $file_slug - The file slug.
 	 * @param string               $extension - The file extension.
 	 *
-	 * @return string
+	 * @return non-empty-string
 	 */
 	public function get_dist_file( string $file_slug, string $extension ): string {
 		$js_dir = apply_filters( 'advanced-sidebar-menu/js-dir', ADVANCED_SIDEBAR_MENU_URL . 'js/dist/' );


### PR DESCRIPTION
Fixes version conflict while we wait for
- php-stubs/wp-cli-stubs to publish new version
- szepeviktor/phpstan-wordpress to publish new version